### PR TITLE
Fix: Ignore composer.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea
 /vendor
 /bin
+composer.lock


### PR DESCRIPTION
This PR
- [x] adds `composer.lock` to `.gitignore`
